### PR TITLE
Html metadata scrape function

### DIFF
--- a/controllers/scrape_html_metadata.js
+++ b/controllers/scrape_html_metadata.js
@@ -1,4 +1,6 @@
 var scrape = require('html-metadata');
+var wordCount = require('html-word-count');
+var request = require('request');
 
 module.exports = (url, callback) => {
     scrape(url).then(metadata => {
@@ -6,6 +8,25 @@ module.exports = (url, callback) => {
         urlObject.content_type = metadata.openGraph.type || "Website";
         urlObject.length = metadata.twitter.data1 ? parseInt(metadata.twitter.data1) : 0;
         urlObject.category = metadata.jsonLd["@type"] || "Web page";
-        callback(urlObject);
+        if (urlObject.length === 0 ) {
+            getLength(url, function(length) {
+                urlObject.length = length;
+                console.log(urlObject);
+            });
+        }
+        else {
+            callback(urlObject);
+        }
+
+    });
+};
+
+function getLength(url, callback) {
+    request(url, function (error, response, body) {
+//        console.log('error:', error); // Print the error if one occurred
+        const count = wordCount(body);
+        // adults read about 200 wpm according to https://www.irisreading.com/the-average-reading-speed/
+        const rate = 200;
+        callback(parseInt(Math.ceil(count/rate)));
     });
 };

--- a/controllers/scrape_html_metadata.js
+++ b/controllers/scrape_html_metadata.js
@@ -6,18 +6,12 @@ module.exports = (url, callback) => {
     scrape(url).then(metadata => {
         var urlObject = {url: url};
         urlObject.content_type = metadata.openGraph.type || "Website";
-        urlObject.length = metadata.twitter.data1 ? parseInt(metadata.twitter.data1) : 0;
         urlObject.category = metadata.jsonLd["@type"] || "Web page";
-        if (urlObject.length === 0 ) {
-            getLength(url, function(length) {
-                urlObject.length = length;
-                console.log(urlObject);
-            });
-        }
-        else {
-            callback(urlObject);
-        }
 
+        getLength(url, function(length) {
+            urlObject.length = length;
+            console.log(urlObject);
+        });
     });
 };
 

--- a/controllers/scrape_html_metadata.js
+++ b/controllers/scrape_html_metadata.js
@@ -1,0 +1,11 @@
+var scrape = require('html-metadata');
+
+module.exports = (url, callback) => {
+    scrape(url).then(metadata => {
+        var urlObject = {url: url};
+        urlObject.content_type = metadata.openGraph.type || "Website";
+        urlObject.length = metadata.twitter.data1 ? parseInt(metadata.twitter.data1) : 0;
+        urlObject.category = metadata.jsonLd["@type"] || "Web page";
+        callback(urlObject);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "crypto-random-string": "^1.0.0",
     "express": "^4.15.4",
     "html-metadata": "git://github.com/wikimedia/html-metadata.git",
+    "html-word-count": "^2.0.0",
     "mysql": "^2.14.1",
     "mysql2": "^1.4.0",
+    "request": "^2.81.0",
     "sequelize": "^4.4.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.17.2",
     "crypto-random-string": "^1.0.0",
     "express": "^4.15.4",
+    "html-metadata": "git://github.com/wikimedia/html-metadata.git",
     "mysql": "^2.14.1",
     "mysql2": "^1.4.0",
     "sequelize": "^4.4.10"


### PR DESCRIPTION
This function uses a few new packages to set a urlObject with properties we want to store in the database. Turns out twitter metadata tags aren't standardized.. so I had to compute lengths myself. I'll try to find some videos and audio to test those. For a suggested read time of 12 min according to a twitter metadata tag, my calculation came out to 16 min.

it takes in a url and a callback then:
* creates a urlObject object
* sets the url property of urlObjecct to the passed url
* scrapes the metadata tags off and tries to set the urlObject.content_type and urlObject.category properties
* calls a function to pull the number of words off the page and calculate a length of reading time based on a 200 wpm average reading time. sets urlObject.length as that time.
* calls the callback on the urlObject

This isn't used anywhere in the code, i've just tested it out in node by requiring it and passing some urls:

```
$ node
 > const scraper = require("./scrape_html_metadata.js");
 > scraper("https://hackernoon.com/your-node-js-authentication-tutorial-is-wrong-f1a3bf831a46", console.log);
 >{ url: 'https://hackernoon.com/your-node-js-authentication-tutorial-is-wrong-f1a3bf831a46',
  content_type: 'article',
  length: 16,
  category: 'NewsArticle' }```


