### PR TITLE
fix /api/urls GET routes

### DIFF
--- a/routes/url-api-routes.js
+++ b/routes/url-api-routes.js
@@ -43,7 +43,7 @@ module.exports = function(app) {
   // });
 
 
-  // POST route to get all the URLs for thex session ID and length
+  // POST route to get all the URLs for the session ID and length
       app.post("/api/urls/:pw/:length", function(req, res) {
         db.User.create(req.body).then(function(dbUser) {
           res.json(dbUser);

--- a/routes/url-api-routes.js
+++ b/routes/url-api-routes.js
@@ -12,6 +12,19 @@ module.exports = function(app) {
       });
   });
 
+// GET route for filtering by length
+    app.get("/api/urls/:pw/:length", function(req, res) {
+        db.user.findAll({
+            include: [{model: db.url,
+                       where: {length: {$lte: req.params.length}}
+                      }],
+            where: {sessionId: req.params.pw}
+        }).then(function(dbUser) {
+            res.json(dbUser);
+        });
+    });
+
+
 // POST route to get all the URLs for the session ID
   app.post("/api/urls/:pw", function(req, res) {
     db.url.create(req.body).then(function(dbUser) {
@@ -29,17 +42,6 @@ module.exports = function(app) {
   //   });
   // });
 
-  // GET route for filtering by length
-    app.get("/api/urls/:pw/:length", function(req, res) {
-      db.url.findAll({
-          include: [{model: db.url}],
-          where: {sessionId: req.params.pw,
-                  length: {$lt: req.params.length}
-                 }
-      }).then(function(dbUser) {
-        res.json(dbUser);
-      });
-    });
 
   // POST route to get all the URLs for thex session ID and length
       app.post("/api/urls/:pw/:length", function(req, res) {

--- a/routes/url-api-routes.js
+++ b/routes/url-api-routes.js
@@ -1,23 +1,20 @@
-
 var db = require("../models");
 
 module.exports = function(app) {
 
 // GET route to get session ID
   app.get("/api/urls/:pw", function(req, res) {
-    db.Url.findAll({
-      include: [db.url],
-        where: {
-          sessionId: req.params.pw
-        }
-    }).then(function(dbUser) {
-      res.json(dbUser);
-    });
+      db.user.findAll({
+          include: [{model: db.url}],
+          where: {sessionId: req.params.pw}
+      }).then(function(dbUser) {
+          res.json(dbUser);
+      });
   });
 
 // POST route to get all the URLs for the session ID
   app.post("/api/urls/:pw", function(req, res) {
-    db.Url.create(req.body).then(function(dbUser) {
+    db.url.create(req.body).then(function(dbUser) {
       res.json(dbUser);
     });
   });
@@ -33,23 +30,18 @@ module.exports = function(app) {
   // });
 
   // GET route for filtering by length
-    app.get("/api/urls/:pw/length", function(req, res) {
+    app.get("/api/urls/:pw/:length", function(req, res) {
       db.url.findAll({
-        include: [db.url],
-          where: {
-            sessionId: req.params.pw,
-            length: {
-              $lt: {
-              length
-            }
-          }
-        }
+          include: [{model: db.url}],
+          where: {sessionId: req.params.pw,
+                  length: {$lt: req.params.length}
+                 }
       }).then(function(dbUser) {
         res.json(dbUser);
       });
     });
 
-  // POST route to get all the URLs for the session ID and length
+  // POST route to get all the URLs for thex session ID and length
       app.post("/api/urls/:pw/:length", function(req, res) {
         db.User.create(req.body).then(function(dbUser) {
           res.json(dbUser);


### PR DESCRIPTION
This fixes the /api/urls/:pw and /api/urls/:pw/:length GET routes.

/api/urls/:pw/:length returns all matching rows with length less than or equal to the length in the param